### PR TITLE
Update GCP example to use varsets

### DIFF
--- a/gcp/README.md
+++ b/gcp/README.md
@@ -6,7 +6,7 @@ To execute this configuration you will need to give Terraform access to the rele
 
 More information on configuration here is available from the [documentation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/provider_reference#authentication).
 
-Once the Terraform configuration has been applied you should save the `workload_identity_pool_provider` and `service_account_email` outputs as you will need them later.
+Once the Terraform configuration has been applied you should save the `varset` output as you will need them later.
 
 ## Terraform Stacks
 
@@ -15,17 +15,16 @@ You can now authenticate a GCP provider in Stacks with the following setup:
 ```hcl
 # main.tfdeploy.hcl
 
-identity_token "gcp" {
-    audience = [ <output.workload_identity_pool_provider from earlier Terraform execution> ]
+store "varset" "credentials" {
+  id       = <output.varset from earlier Terraform execution>
+  category = "terraform"  
 }
 
 deployment "development" {
   inputs = {
     google_project               = <the same project used in the setup>
     google_region                = <the same region used in the setup>
-    google_audience              = <output.workload_identity_pool_provider from earlier Terraform execution>
-    google_token_file            = identity_token.gcp.token_file
-    google_service_account_email = <output.service_account_email from earlier Terraform execution>
+    google_credentials           = store.varset.credentials.gcp_credentials
   }  
 }
 
@@ -35,41 +34,23 @@ deployment "development" {
 # main.tfstack.hcl
 
 variable "google_project" {
-    type = string
+  type = string
 }
 
 variable "google_region" {
-    type = string
+  type = string
 }
 
-variable "google_audience" {
-    type = string
-}
-
-variable "google_token_file" {
-    type = string
-}
-
-variable "google_service_account_email" {
-    type = string
+variable "google_credentials" {
+  type      = string
+  ephemeral = true  
 }
 
 provider "google" "this" {
   config {
-    project = var.google_project
-    region  = var.google_region
-    credentials = jsonencode(
-      {
-        "type": "external_account",
-        "audience": var.google_audience,
-        "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
-        "token_url": "https://sts.googleapis.com/v1/token",
-        "credential_source": {
-          "file": var.google_token_file,
-         },
-         "service_account_impersonation_url": "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/${var.google_service_account_email}:generateAccessToken",
-      }
-    )
+    project     = var.google_project
+    region      = var.google_region
+    credentials = var.google_credentials
   }
 }
 ```

--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -6,55 +6,16 @@ provider "google" {
   project = var.google_project
 }
 
-resource "google_iam_workload_identity_pool" "stacks_identity_pool" {
-  workload_identity_pool_id = "stacks-${var.tfc_organization}-${var.tfc_project}-${var.tfc_stack}"
-}
-
-locals {
-  # This value decides exactly which HCP Terraform organisations, projects 
-  # and stacks will have access to the chosen GCP project.
-  # 
-  # You can widen access here to an entire organization or project by
-  # tweaking the value below. You can also restrict access to specific
-  # deployments or operations. See the User Guide for more info.
-  sub_starts_with = "organization:${var.tfc_organization}:project:${var.tfc_project}:stack:${var.tfc_stack}"
-}
-
-resource "google_iam_workload_identity_pool_provider" "stacks_identity_pool_provider" {
-  workload_identity_pool_id          = google_iam_workload_identity_pool.stacks_identity_pool.workload_identity_pool_id
-  workload_identity_pool_provider_id = "stacks-${var.tfc_organization}-${var.tfc_project}-${var.tfc_stack}"
-  attribute_mapping = {
-    "google.subject"                            = "assertion.sub",
-    "attribute.aud"                             = "type(assertion.aud) == list ? assertion.aud[0] : assertion.aud",
-    "attribute.terraform_operation"             = "assertion.terraform_operation",
-    "attribute.terraform_stack_deployment_name" = "assertion.terraform_stack_deployment_name",
-    "attribute.terraform_stack_id"              = "assertion.terraform_stack_id",
-    "attribute.terraform_stack_name"            = "assertion.terraform_stack_name",
-    "attribute.terraform_project_id"            = "assertion.terraform_project_id",
-    "attribute.terraform_project_name"          = "assertion.terraform_project_name",
-    "attribute.terraform_organization_id"       = "assertion.terraform_organization_id",
-    "attribute.terraform_organization_name"     = "assertion.terraform_organization_name",
-    "attribute.terraform_plan_id"               = "assertion.terraform_plan_id"
-  }
-  oidc {
-    issuer_uri = "https://app.terraform.io"
-  }
-
-  // only my organisation can access, and only from the stacks project
-  attribute_condition = "assertion.sub.startsWith(\"${local.sub_starts_with}\")"
-}
+# First, we create a GCP service account.
 
 resource "google_service_account" "stacks_service_account" {
-  account_id   = "stacks-${var.tfc_organization}-${var.tfc_project}-${var.tfc_stack}"
+  account_id   = "stacks"
   display_name = "Terraform Stacks Service Account"
 }
 
-resource "google_service_account_iam_member" "stacks_service_account_membership" {
-  service_account_id = google_service_account.stacks_service_account.name
-  role               = "roles/iam.workloadIdentityUser"
-  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.tfc.name}/*"
+resource "google_service_account_key" "stacks_service_account" {
+  service_account_id = google_service_account.stacks_service_account.id
 }
-
 
 # Now, we're going to give the new service account access to things we're going to be managing in our stack.
 #
@@ -68,10 +29,25 @@ resource "google_project_iam_member" "stacks_service_account_membership" {
   member  = "serviceAccount:${google_service_account.stacks_service_account.email}"
 }
 
-output "workload_identity_pool_provider" {
-  value = google_iam_workload_identity_pool_provider.stacks_identity_pool_provider.id
+# Now, we'll upload the credentials for the service account to HCP Terraform.
+
+provider "tfe" {}
+
+resource "tfe_variable_set" "variables" {
+  name         = "gcp-stacks"
+  description  = "Credentials for accessing GCP"
+  organization = var.tfc_organisation
 }
 
-output "service_account_email" {
-  value = google_service_account.stacks_service_account.email
+resource "tfe_variable" "gcp_credentials" {
+  key             = "gcp_credentials"
+  value           = base64decode(google_service_account_key.stacks_service_account.private_key)
+  category        = "terraform"
+  description     = "Credentials for accessing GCP"
+  variable_set_id = tfe_variable_set.variables.id
+  sensitive       = true
+}
+
+output "varset" {
+  value = tfe_variable_set.variables.id
 }

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -16,7 +16,3 @@ variable "tfc_organization" {
 variable "tfc_project" {
   type = string
 }
-
-variable "tfc_stack" {
-  type = string
-}


### PR DESCRIPTION
We're about to deprecate the `token_file` approach for identity tokens. This will mean Google users must authenticate via service account credentials instead.